### PR TITLE
Validation

### DIFF
--- a/.circle.yml
+++ b/.circle.yml
@@ -1,0 +1,8 @@
+---
+deployment:
+  master:
+    branch: master
+    commands:
+      - echo -e "$GPG_SECRET_KEY" > .private.key
+      - gpg --batch --yes --allow-secret-key --import .private.key
+      

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-config "0.4.4"
+(defproject clj-config "1.0.0"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -7,4 +7,5 @@
                  [org.clojure/tools.logging "0.3.1"]]
   :repositories [["primedia"
                   {:url "http://nexus.idg.primedia.com/nexus/content/repositories/primedia"
-                   :sign-releases false}]])
+                   :sign-releases false}]]
+  :signing {:gpg-key "164E1387"})

--- a/src/clj_config/app.clj
+++ b/src/clj_config/app.clj
@@ -23,8 +23,8 @@
 
             (fn mzip-make-node
               [x children]
-              (if (map? x) 
-                (into {} children) 
+              (if (map? x)
+                (into {} children)
                 (assoc x 1 (into {} children))))
             m))
 
@@ -42,18 +42,18 @@
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Used when validating that app-config contains all required vars  
+;; Used when validating that app-config contains all required vars
 (defn keys-in
   "courtesy of A.Webb:
    http://stackoverflow.com/a/21770247"
-  [m] 
-  (letfn [(branch? [[path m]] (map? m)) 
-          (children [[path m]] (for [[k v] m] [(conj path k) v]))] 
-    (let [key-paths (if (empty? m) 
+  [m]
+  (letfn [(branch? [[path m]] (map? m))
+          (children [[path m]] (for [[k v] m] [(conj path k) v]))]
+    (let [key-paths (if (empty? m)
                       []
-                      (loop [t (z/zipper branch? children nil [[] m]), paths []] 
-                        (cond (z/end? t) paths 
-                              (z/branch? t) (recur (z/next t), paths) 
+                      (loop [t (z/zipper branch? children nil [[] m]), paths []]
+                        (cond (z/end? t) paths
+                              (z/branch? t) (recur (z/next t), paths)
                               :leaf (recur (z/next t), (conj paths (first (z/node t)))))))]
 
       (reduce (fn [c x]
@@ -90,9 +90,9 @@
     :default   - keyword indicating default (in case the current env is not represented at a given choice point)
     :config    - an edn map stucture representing application config,
                  possibly containing multiple options for a provided key.
-    
+
     env    - the current application environment
-    
+
     Example:
              {:sentry-dsn {[:ci :dev] \"\"
                             :qa       \"qa-url.sentry.com\"

--- a/src/clj_config/config_entry.clj
+++ b/src/clj_config/config_entry.clj
@@ -38,6 +38,9 @@
       true
       false)))
 
+(def has-default?
+  (comp #{::none} #(get % :default)))
+
 (defrecord ConfigEntry
     [env lookup-key validator]
 

--- a/src/clj_config/config_entry.clj
+++ b/src/clj_config/config_entry.clj
@@ -38,8 +38,9 @@
       true
       false)))
 
+(def +default-sentinel+ ::none)
 (def has-default?
-  (comp #{::none} #(get % :default)))
+  (comp not #{+default-sentinel+} #(get % :default)))
 
 (defrecord ConfigEntry
     [env lookup-key validator]
@@ -56,11 +57,7 @@
         (throw (ex-info (format "Config data not found: %s"
                                 (pr-str (dissoc this :validator)))
                         this))
-        value)))
-
-  clojure.lang.Named
-  (getName [_] lookup-key)
-  (getNamespace [_] env))
+        value))))
 
 (defmulti ->config-entry
   (fn [env config-entry options] env))
@@ -69,6 +66,6 @@
 (defmethod ->config-entry :default
   [env lookup-key {:keys [default validator] :as options
                    :or {validator +default-validator+
-                        default ::none}}]
+                        default +default-sentinel+}}]
   (assoc (->ConfigEntry env lookup-key validator)
          :default default))

--- a/src/clj_config/config_entry.clj
+++ b/src/clj_config/config_entry.clj
@@ -1,0 +1,82 @@
+(ns clj-config.config-entry)
+
+(defprotocol IValidate
+  (-valid? [this value] "Return true if the value is valid, false otherwise."))
+
+(extend-type clojure.lang.IFn
+(defn ->vec
+  [x]
+  (if (sequential? x)
+    x
+    (vector x)))
+
+  IValidate
+  (-valid? [this value]
+    (this value)))
+(defn get-in*
+  "Get k from m, barf if not found (unless provided a default value).
+   Wrap k in a vector if k is not already
+   "
+  ([m k]
+   (when-not m (throw (ex-info "config not initialized" {})))
+   (let [value (get-in m (->vec k) ::not-found)]
+     (if (= value ::not-found)
+       (throw (ex-info (str "config var " k " not set") {}))
+       value)))
+  ([m k not-found]
+   (when-not m (throw (ex-info "config not initialized" {})))
+   (get-in m (->vec k) not-found)))
+
+(defmulti classify-definition
+  (fn [env definition]
+    [env (type definition)]))
+
+(defmethod classify-definition :default
+  [env definition]
+  (throw (ex-info (format "Invalid config definition: %s env: %s ns:"
+                          (pr-str definition) (pr-str env) (pr-str *ns*))
+                  {:env env
+                   :ns *ns*
+                   :definition definition})))
+
+(defmethod classify-definition [:env String]
+  [_ _]
+  :unvalidated)
+
+(defmethod classify-definition [:env clojure.lang.IPersistentVector]
+  [_ _]
+  :validated)
+
+(defmethod classify-definition [:app clojure.lang.IPersistentVector]
+  [_ definition]
+  (if (vector? (first definition))
+    :validated
+    :unvalidated))
+
+(defmethod classify-definition [:app clojure.lang.Keyword]
+  [_ _]
+  :unvalidated)
+
+(defmulti read-config-def
+  (fn [env definition]
+    [env (classify-definition env definition)]))
+
+(defmethod read-config-def [:env :unvalidated]
+  [_ definition]
+  {:lookup-key definition
+   :validator `(constantly true)})
+
+(defmethod read-config-def [:env :validated]
+  [_ definition]
+  {:lookup-key (first definition)
+   :validator  (second definition)})
+
+(defmethod read-config-def [:app :unvalidated]
+  [_ definition]
+  {:lookup-key definition
+   :validator `(constantly true)})
+
+(defmethod read-config-def [:app :validated]
+  [_ definition]
+  {:lookup-key (first definition)
+   :validator (second definition)})

--- a/src/clj_config/core.clj
+++ b/src/clj_config/core.clj
@@ -4,7 +4,8 @@
             [clojure.string :refer [trim] :as s]
             [clojure.set :as set]
             [clojure.tools.logging :as log]
-            [clj-config.app :as app])
+            [clj-config.app :as app]
+            [clj-config.config-entry :as entry :refer [read-config-def]])
   (:import [java.util Properties]
            [java.io File]))
 
@@ -32,26 +33,6 @@
   [root basename]
   (clojure.string/join File/separator (list root basename)))
 
-(defn ->vec
-  [x]
-  (if (sequential? x)
-    x
-    (vector x)))
-
-(defn get-in*
-  "Get k from m, barf if not found (unless provided a default value).
-   Wrap k in a vector if k is not already
-   "
-  ([m k]
-     (when-not m (throw (ex-info "config not initialized" {})))
-     (let [value (get-in m (->vec k) ::not-found)]
-       (if (= value ::not-found)
-         (throw (ex-info (str "config var " k " not set") {}))
-         value)))
-  ([m k not-found]
-     (when-not m (throw (ex-info "config not initialized" {})))
-     (get-in m (->vec k) not-found)))
-
 (defn system-get-env
   ([] (System/getenv))
   ([key] (System/getenv key)))
@@ -75,12 +56,12 @@
 (def required-env (atom #{}))
 
 (defn env-config-def
-  [[name env-varname]]
-  (assert (and (symbol? name) (string? env-varname)))
-  `((swap! required-env conj ~env-varname)
-    (def ~name
-      (reify clojure.lang.IDeref
-        (deref [this#] (get-in* config ~env-varname))))))
+  [[name env-varname opts]]
+  (let [{:keys [lookup-key validator] :as def} (read-config-def :env env-varname)]
+    `((swap! required-env conj ~def)
+      (def ~name
+        (reify clojure.lang.IDeref
+          (deref [this#] (get-in* config ~lookup-key)))))))
 
 ;;;;;;;; app config
 
@@ -103,11 +84,11 @@
 
 (defn app-config-def
   [[name env-varname]]
-  (assert (and (symbol? name) (every? keyword? (->vec env-varname))))
-  `((swap! required-app-config conj ~env-varname)
+  `((swap! required-app-config conj ~(read-config-def :app env-varname))
     (def ~name
       (reify clojure.lang.IDeref
         (deref [this#] (get-in* app-config ~env-varname))))))
+  (assert (and (symbol? name) (every? keyword? (entry/->vec env-varname))))
 
 ;;;;;;;;;;;;;;;;;;;;
 ;;
@@ -116,6 +97,33 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;
 
+(defn valid-app-config?
+  [required-app-config actual-config]
+  (let [validators (into {} (map (juxt :lookup-key :validator) required-app-config))]
+    (assert (->> required-app-config
+                 (map :lookup-key)
+                 (every? (partial app/contains-keypath? actual-config)))
+            (format "Not all required APP configuration vars are defined. Missing vars: %s"
+                    (pr-str (remove (partial app/contains-keypath?
+                                             actual-config)
+                                    (map :lookup-key required-app-config)))))
+    (assert (->> validators
+                 (map (fn [[key-path validator]]
+                        [validator (get-in* actual-config key-path ::not-found)]))
+                 (every? #(entry/-valid? (first %) (second %))))
+            ;; (format "Not all required APP variables pass validation: %s"
+            ;;         (->> validators
+            ;;              (map (fn [[k v]] [(entry/-valid? (get validators k (constantly false))
+            ;;                                               v)
+            ;;                                k]))
+            ;;              (remove (fn [[passed? keyname]] passed?))
+            ;;              (map (comp pr-str second))
+            ;;              (sort)
+            ;;              (interpose " ")
+            ;;              (apply str)))
+            )
+    true))
+
 (defn init-app-config!
   ([env] (init-app-config! env (System/getProperty "user.dir")))
   ([env root-dir]
@@ -123,12 +131,32 @@
                            (get-in* env "CLJ_APP_CONFIG" (str root-dir (System/getProperty "file.separator") "config.edn")))
          app-environment (get-in* env "APPLICATION_ENVIRONMENT" "dev")
          app-config (read-app-config app-config-file app-environment)]
-     (assert (every? (partial app/contains-keypath? app-config) @required-app-config)
-             (format "Not all required APP configuration vars are defined. Missing vars: %s"
-                     (pr-str (remove (partial app/contains-keypath?
-                                              app-config)
-                                     @required-app-config))))
-     (alter-var-root #'app-config (constantly app-config)))))
+     (when (valid-app-config? @required-app-config app-config)
+       (alter-var-root #'app-config (constantly app-config))))))
+
+
+(defn valid-env-config?
+  [required-env actual-config]
+  (let [validators (into {} (map (juxt :lookup-key :validator) required-env))
+        required-names (into #{} (keys validators))]
+    (assert (set/subset? required-names (set (keys actual-config)))
+            (format "Not all required ENV configuration vars are defined. Missing vars: %s"
+                    (pr-str (set/difference required-names (set (keys config))))))
+    (assert (->> validators
+                 (map (fn [[key validator]]
+                        [validator (get actual-config key ::not-found)]))
+                 (every? #(entry/-valid? (first %) (second %))))
+            (format "Not all required ENV variables pass validation: %s"
+                    (->> validators
+                         (map (fn [[k v]] [(entry/-valid? (get validators k (constantly false))
+                                                          v)
+                                           k]))
+                         (remove (fn [[passed? keyname]] passed?))
+                         (map (comp pr-str second))
+                         (sort)
+                         (interpose " ")
+                         (apply str))))
+    true))
 
 (defn init!
   ([]
@@ -136,12 +164,10 @@
               (System/getProperty "user.dir"))))
   ([root-dir]
    (let [config (read-env root-dir)]
-     (assert (set/subset? @required-env (set (keys config)))
-             (format "Not all required ENV configuration vars are defined. Missing vars: %s"
-                     (pr-str (set/difference @required-env (set (keys config))))))
-     (alter-var-root #'config (constantly config))
+     (when (valid-env-config? @required-env config)
+       (alter-var-root #'config (constantly config))
 
-     (init-app-config! config root-dir))))
+       (init-app-config! config root-dir)))))
 
 (defmacro defconfig
   "
@@ -184,4 +210,13 @@
 
   (defconfig
     :app {sentry-url :sentry-dsn}
-    :env {oracle-url "DATASTORES_ORACLE_WEBICON_HOSTNAME"}))
+    :env {oracle-url "DATASTORES_ORACLE_WEBICON_HOSTNAME"})
+
+  (do
+    (defconfig
+      :env [[home "HOME" (constantly true)]])
+    (init!)
+    @home)
+
+
+  )

--- a/src/clj_config/core.clj
+++ b/src/clj_config/core.clj
@@ -121,9 +121,9 @@
   ([env root-dir]
    (let [app-config-file (when (seq @required-app-config)
                            (entry/get-in* env "CLJ_APP_CONFIG"
-                                          (str root-dir (System/getProperty "file.separator")
-                                               "config.edn")))
-         app-environment (entry/get-in* env "APPLICATION_ENVIRONMENT" "dev")
+                                          {:default
+                                           (str root-dir (System/getProperty "file.separator") "config.edn")}))
+         app-environment (entry/get-in* env "APPLICATION_ENVIRONMENT" {:default "dev"})
          app-config (read-app-config app-config-file app-environment)]
      (when (valid-app-config? @required-app-config app-config)
        (alter-var-root #'app-config (constantly app-config))))))

--- a/src/clj_config/core.clj
+++ b/src/clj_config/core.clj
@@ -189,15 +189,5 @@
   (require '[clj-config.core :refer [defconfig]])
 
   (defconfig
-    :app {sentry-url :sentry-dsn}
-    :env {oracle-url "DATASTORES_ORACLE_WEBICON_HOSTNAME"})
-
-  (do
-    (defconfig
-      :env [[home "HOME" {:validator #"[/A-Za-z0-9]"}]
-            [bazorz "FLKD" {:default "foo"}]])
-    (init!)
-    @bazorz)
-
-
-  )
+    :app [[sentry-url :sentry-dsn]]
+    :env [[oracle-url "DATASTORES_ORACLE_WEBICON_HOSTNAME"]]))

--- a/src/clj_config/core.clj
+++ b/src/clj_config/core.clj
@@ -117,17 +117,18 @@
 ;;;;;;;;;;;;;;;;;;;;
 
 (defn init-app-config!
-  [env root-dir]
-  (let [app-config-file (when (seq @required-app-config)
-                          (get-in* env "CLJ_APP_CONFIG" (str root-dir (System/getProperty "file.separator") "config.edn")))
-        app-environment (get-in* env "APPLICATION_ENVIRONMENT" "dev")
-        app-config (read-app-config app-config-file app-environment)]
-    (assert (every? (partial app/contains-keypath? app-config) @required-app-config)
-            (format "Not all required APP configuration vars are defined. Missing vars: %s"
-                    (pr-str (remove (partial app/contains-keypath?
-                                             app-config)
-                                    @required-app-config))))
-    (alter-var-root #'app-config (constantly app-config))))
+  ([env] (init-app-config! env (System/getProperty "user.dir")))
+  ([env root-dir]
+   (let [app-config-file (when (seq @required-app-config)
+                           (get-in* env "CLJ_APP_CONFIG" (str root-dir (System/getProperty "file.separator") "config.edn")))
+         app-environment (get-in* env "APPLICATION_ENVIRONMENT" "dev")
+         app-config (read-app-config app-config-file app-environment)]
+     (assert (every? (partial app/contains-keypath? app-config) @required-app-config)
+             (format "Not all required APP configuration vars are defined. Missing vars: %s"
+                     (pr-str (remove (partial app/contains-keypath?
+                                              app-config)
+                                     @required-app-config))))
+     (alter-var-root #'app-config (constantly app-config)))))
 
 (defn init!
   ([]

--- a/src/clj_config/core.clj
+++ b/src/clj_config/core.clj
@@ -100,7 +100,7 @@
 
 (defn valid-app-config?
   [app-config-entries actual-config]
-  (let [required-names (into #{} (map name (remove :default app-config-entries)))]
+  (let [required-names (into #{} (map name (remove entry/has-default? app-config-entries)))]
     (assert (set/subset? required-names (set (keys actual-config)))
             (format "Not all required APP configuration vars are defined. Missing vars: %s"
                     (pr-str (set/difference required-names (set (keys actual-config))))))
@@ -127,7 +127,7 @@
 
 (defn valid-env-config?
   [env-config-entries actual-config]
-  (let [required-names (into #{} (map name (remove :default env-config-entries)))]
+  (let [required-names (into #{} (map name (remove entry/has-default? env-config-entries)))]
     (assert (set/subset? required-names (set (keys actual-config)))
             (format "Not all required ENV configuration vars are defined. Missing vars: %s"
                     (pr-str (set/difference required-names (set (keys actual-config))))))

--- a/test/clj_config/app_config_test.clj
+++ b/test/clj_config/app_config_test.clj
@@ -55,14 +55,23 @@
 
 (deftest defconfig-populates-required-vars
   (eval `(defconfig :app {~'default-port :java-listening-port}))
-  (is (= #{:java-listening-port} @required-app-config))
+  (is (= #{:java-listening-port}
+         (->>  @required-app-config
+               (map :lookup-key)
+               (into #{}))))
 
   (eval `(defconfig :app {~'foo :foo-value}))
-  (is (= #{:java-listening-port :foo-value} @required-app-config))
+  (is (= #{:java-listening-port :foo-value}
+         (->> @required-app-config
+              (map :lookup-key)
+              (into #{}))))
 
   (testing "correctly handles key-path"
     (eval `(defconfig :app {~'bar [:key :path]}))
-    (is (= #{:java-listening-port :foo-value [:key :path]} @required-app-config))))
+    (is (= #{:java-listening-port :foo-value [:key :path]}
+           (->> @required-app-config
+                (map :lookup-key)
+                (into #{}))))))
 
 (deftest init-app-config-verifies-required-values
   (let [env {"APPLICATION_ENVIRONMENT" "dev"

--- a/test/clj_config/app_config_test.clj
+++ b/test/clj_config/app_config_test.clj
@@ -3,6 +3,7 @@
             [clojure.edn :as edn]
             [clj-config.app :as app]
             [clj-config.core :refer :all]
+            [clj-config.config-entry :as entry]
             [clj-config.test-helper :refer :all]))
 
 (defn resetting [f]
@@ -75,14 +76,16 @@
 
 (deftest init-app-config-verifies-required-values
   (let [env {"APPLICATION_ENVIRONMENT" "dev"
-             "CLJ_APP_CONFIG" "test/fixtures/app_config.edn"}]
-    (swap! required-app-config conj :important-but-missing-value)
+             "CLJ_APP_CONFIG" "test/fixtures/app_config.edn"}
+        config-entry (entry/->config-entry :app :important-but-missing-value nil)]
+    (swap! required-app-config conj config-entry)
     (is (thrown? AssertionError (init-app-config! env)))))
 
 (deftest false-values-satisfy-required-check
   (let [env {"APPLICATION_ENVIRONMENT" "dev"
-             "CLJ_APP_CONFIG" "test/fixtures/app_config.edn"}]
-    (swap! required-app-config conj :false-value)
+             "CLJ_APP_CONFIG" "test/fixtures/app_config.edn"}
+        config-entry (entry/->config-entry :app :false-value nil)]
+    (swap! required-app-config conj config-entry)
     (is (init-app-config! env))))
 
 (deftest reading-and-transforming-app-config

--- a/test/clj_config/app_config_test.clj
+++ b/test/clj_config/app_config_test.clj
@@ -95,7 +95,7 @@
   (let [env {"APPLICATION_ENVIRONMENT" "ci"}]
     (eval `(do (in-ns 'clj-config.app-config-test)
                (defconfig :app {~'sentry-dsn :sentry-dsn})))
-    (is (thrown? clojure.lang.ExceptionInfo (init-app-config! env)))))
+    (is (thrown? java.io.FileNotFoundException (init-app-config! env)))))
 
 (deftest no-app-config-file-without-defconfig
   (with-fake-env {}
@@ -141,4 +141,3 @@
     (is (= "mittens-dev" @@(resolve 'user)))
     (init-app-config! (assoc env "APPLICATION_ENVIRONMENT" "qa"))
     (is (= "mittens-qa" @@(resolve 'user)))))
-

--- a/test/clj_config/app_config_test.clj
+++ b/test/clj_config/app_config_test.clj
@@ -55,20 +55,20 @@
                          :pwd "m30w"}}})
 
 (deftest defconfig-populates-required-vars
-  (eval `(defconfig :app {~'default-port :java-listening-port}))
+  (eval `(defconfig :app [[~'default-port :java-listening-port]]))
   (is (= #{:java-listening-port}
          (->>  @required-app-config
                (map :lookup-key)
                (into #{}))))
 
-  (eval `(defconfig :app {~'foo :foo-value}))
+  (eval `(defconfig :app [[~'foo :foo-value]]))
   (is (= #{:java-listening-port :foo-value}
          (->> @required-app-config
               (map :lookup-key)
               (into #{}))))
 
   (testing "correctly handles key-path"
-    (eval `(defconfig :app {~'bar [:key :path]}))
+    (eval `(defconfig :app [[~'bar [:key :path]]]))
     (is (= #{:java-listening-port :foo-value [:key :path]}
            (->> @required-app-config
                 (map :lookup-key)
@@ -99,14 +99,14 @@
   (let [env {"CLJ_APP_CONFIG" "test/fixtures/app_config.edn"
              "APPLICATION_ENVIRONMENT" "ci"}]
     (eval `(do (in-ns 'clj-config.app-config-test)
-               (defconfig :app {~'sentry-dsn :sentry-dsn})))
+               (defconfig :app [[~'sentry-dsn :sentry-dsn]])))
     (init-app-config! env)
     (is (= "ci/qa sentry dsn" @@(resolve 'sentry-dsn)))))
 
 (deftest no-env-config-file
   (let [env {"APPLICATION_ENVIRONMENT" "ci"}]
     (eval `(do (in-ns 'clj-config.app-config-test)
-               (defconfig :app {~'sentry-dsn :sentry-dsn})))
+               (defconfig :app [[~'sentry-dsn :sentry-dsn]])))
     (is (thrown? java.io.FileNotFoundException (init-app-config! env)))))
 
 (deftest no-app-config-file-without-defconfig
@@ -127,7 +127,7 @@
   (let [env {"CLJ_APP_CONFIG" "test/fixtures/app_config.edn"
              "APPLICATION_ENVIRONMENT" "ci"}]
     (eval `(do (in-ns 'clj-config.app-config-test)
-               (defconfig :app {~'user [:nested :usr]})))
+               (defconfig :app [[~'user [:nested :usr]]])))
     (init-app-config! env)
     (is (= "mittens-dev" @@(resolve 'user)))))
 
@@ -135,9 +135,9 @@
   (let [env {"CLJ_APP_CONFIG" "test/fixtures/app_config.edn"
              "APPLICATION_ENVIRONMENT" "ci"}]
     (eval `(do (in-ns 'clj-config.app-config-test)
-               (defconfig :app {~'ncfg    :nested
-                                ~'user   [:nested :usr]
-                                ~'pass   [:nested :pwd]})))
+               (defconfig :app [[~'ncfg    :nested]
+                                [~'user   [:nested :usr]]
+                                [~'pass   [:nested :pwd]]])))
     (init-app-config! env)
     (is (=  {:url "moarcats.gov" :pwd "m30w" :usr "mittens-dev"}
             @@(resolve 'ncfg)))
@@ -148,7 +148,7 @@
   (let [env {"CLJ_APP_CONFIG" "test/fixtures/app_config.edn"
              "APPLICATION_ENVIRONMENT" "ci"}]
     (eval `(do (in-ns 'clj-config.app-config-test)
-               (defconfig :app {~'user [:nested :usr]})))
+               (defconfig :app [[~'user [:nested :usr]]])))
     (init-app-config! env)
     (is (= "mittens-dev" @@(resolve 'user)))
     (init-app-config! (assoc env "APPLICATION_ENVIRONMENT" "qa"))

--- a/test/clj_config/app_config_test.clj
+++ b/test/clj_config/app_config_test.clj
@@ -79,7 +79,7 @@
              "CLJ_APP_CONFIG" "test/fixtures/app_config.edn"}
         config-entry (entry/->config-entry :app :important-but-missing-value nil)]
     (swap! required-app-config conj config-entry)
-    (is (thrown? clojure.lang.ExceptionInfo (init-app-config! env)))))
+    (is (thrown? AssertionError (init-app-config! env)))))
 
 (deftest false-values-satisfy-required-check
   (let [env {"APPLICATION_ENVIRONMENT" "dev"

--- a/test/clj_config/app_config_test.clj
+++ b/test/clj_config/app_config_test.clj
@@ -79,7 +79,7 @@
              "CLJ_APP_CONFIG" "test/fixtures/app_config.edn"}
         config-entry (entry/->config-entry :app :important-but-missing-value nil)]
     (swap! required-app-config conj config-entry)
-    (is (thrown? AssertionError (init-app-config! env)))))
+    (is (thrown? clojure.lang.ExceptionInfo (init-app-config! env)))))
 
 (deftest false-values-satisfy-required-check
   (let [env {"APPLICATION_ENVIRONMENT" "dev"

--- a/test/clj_config/config_entry_test.clj
+++ b/test/clj_config/config_entry_test.clj
@@ -1,0 +1,45 @@
+(ns clj-config.config-entry-test
+  (:require [clojure.test :refer :all]
+            [clj-config.config-entry :refer :all]))
+
+(deftest test-classify-definition
+  (testing "Happy Path"
+    (are [env definition classification]
+        (= (classify-definition env definition)
+           classification)
+
+      :env "foo"                 :unvalidated
+      :env ["foo" "something"]   :validated
+
+      :app :bare-keyword                       :unvalidated
+      :app [:some :key :path]                  :unvalidated
+      :app [[:some :key :path] :anything-at-all] :validated))
+
+  (testing "Invalid definition"
+    (is (thrown? clojure.lang.ExceptionInfo (classify-definition :env 'symbol))
+        "The classify-definition multimethod should throw an exception
+         when it encounters a config definition it doesn't understand.")
+    (let [data (ex-data (try (classify-definition :env 'symbol)
+                             (catch clojure.lang.ExceptionInfo e e)))]
+      (are [key expected-value]
+          (= (get data key ::not-found) expected-value)
+
+        :ns *ns*
+        :env :env
+        :definition 'symbol))))
+
+(deftest test-read-config-def
+  (testing "Happy Path"
+    (are [env definition lookup-key validator]
+        (let [result (read-config-def env definition)]
+          (and (= validator (:validator result))
+               (= lookup-key (:lookup-key result))))
+
+      :env `["HOME" (constantly false)] "HOME" `(constantly false)
+      :env `"HOME"                      "HOME" `(constantly true)
+
+      :app `[[:some :key :path] (constantly false)]
+            [:some :key :path] `(constantly false)
+
+      :app `:bare-keyword :bare-keyword `(constantly true)
+      :app `[:some :key :path]  [:some :key :path] `(constantly true))))

--- a/test/clj_config/env_config_test.clj
+++ b/test/clj_config/env_config_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer :all]
             [clj-config.core :refer :all]
             [clj-config.test-helper :refer :all]
-            [clj-config.config-entry :refer [get-in*]]))
+            [clj-config.config-entry :as entry :refer [get-in*]]))
 
 (defn resetting [f]
   (reset! required-env #{})
@@ -45,7 +45,7 @@
               (into #{})))))
 
 (deftest init-verifies-presence-of-required-values
-  (swap! required-env conj "IMPORTANT_BUT_MISSING_VALUE")
+  (swap! required-env conj (entry/->config-entry :env "IMPORTANT_BUT_MISSING_VALUE" nil))
   (is (thrown? AssertionError (init! "test/fixtures"))))
 
 (deftest re-init-updates-env-vars

--- a/test/clj_config/env_config_test.clj
+++ b/test/clj_config/env_config_test.clj
@@ -1,7 +1,8 @@
 (ns clj-config.env-config-test
   (:require [clojure.test :refer :all]
             [clj-config.core :refer :all]
-            [clj-config.test-helper :refer :all]))
+            [clj-config.test-helper :refer :all]
+            [clj-config.config-entry :refer [get-in*]]))
 
 (defn resetting [f]
   (reset! required-env #{})
@@ -32,10 +33,16 @@
 
 (deftest defconfig-populates-required-env
   (eval `(defconfig :env {~'default-port "JAVA_LISTENING_PORT"}))
-  (is (= #{"JAVA_LISTENING_PORT"} @required-env))
+  (is (= #{"JAVA_LISTENING_PORT"}
+         (->> @required-env
+              (map :lookup-key)
+              (into #{}))))
 
   (eval `(defconfig :env {~'foo "FOO_VALUE"}))
-  (is (= #{"JAVA_LISTENING_PORT" "FOO_VALUE"} @required-env)))
+  (is (= #{"JAVA_LISTENING_PORT" "FOO_VALUE"}
+         (->> @required-env
+              (map :lookup-key)
+              (into #{})))))
 
 (deftest init-verifies-presence-of-required-values
   (swap! required-env conj "IMPORTANT_BUT_MISSING_VALUE")
@@ -58,4 +65,3 @@
              (defconfig :env {~'foo "OHAI"})))
   (is (thrown? clojure.lang.ExceptionInfo
                @@(resolve 'foo))))
-

--- a/test/clj_config/env_config_test.clj
+++ b/test/clj_config/env_config_test.clj
@@ -32,13 +32,13 @@
       (is (= "overridden" (get-in* computed-env "FROM_INFRA_FILE"))))))
 
 (deftest defconfig-populates-required-env
-  (eval `(defconfig :env {~'default-port "JAVA_LISTENING_PORT"}))
+  (eval `(defconfig :env [[~'default-port "JAVA_LISTENING_PORT"]]))
   (is (= #{"JAVA_LISTENING_PORT"}
          (->> @required-env
               (map :lookup-key)
               (into #{}))))
 
-  (eval `(defconfig :env {~'foo "FOO_VALUE"}))
+  (eval `(defconfig :env [[~'foo "FOO_VALUE"]]))
   (is (= #{"JAVA_LISTENING_PORT" "FOO_VALUE"}
          (->> @required-env
               (map :lookup-key)
@@ -52,7 +52,7 @@
   (with-fake-env {"ENV_FILE" "test/fixtures/sample_env.cfg"
                   "CLJ_APP_CONFIG" "test/fixtures/app_config.edn"}
     (eval `(do (in-ns 'clj-config.env-config-test)
-               (defconfig :env {~'env-var-source "ENV_VAR_SOURCE"})))
+               (defconfig :env [[~'env-var-source "ENV_VAR_SOURCE"]])))
     (init! "test/fixtures"))
   (is (= "sample_env.cfg" @@(resolve 'env-var-source)))
   (with-fake-env {"ENV_FILE" "test/fixtures/.env.local"
@@ -62,6 +62,6 @@
 
 (deftest deref-throws-when-config-is-uninitialized
   (eval `(do (in-ns 'clj-config.env-config-test)
-             (defconfig :env {~'foo "OHAI"})))
+             (defconfig :env [[~'foo "OHAI"]])))
   (is (thrown? clojure.lang.ExceptionInfo
                @@(resolve 'foo))))


### PR DESCRIPTION
Changed how we represent config. From:

``` clojure
(defconfig
  :env {foo "FOO_VAR"
        bar "BAR_VAR"}
  :app {baz [:some :key :path]})
```

To:

``` clojure
(defconfig
  :env [[foo "FOO_VAR"]
        [bar "BAR_VAR"]]
  :app [[baz [:some :key :path]]])
```

This enables us to specify defaults and validators:

``` clojure
(defconfig
  :env [[foo "FOO_VAR" {:default "foo"}]
        [bar "BAR_VAR" {:validator schema/URL}]]
  :app [[baz [:some :key :path]]])
```
