### PR TITLE
Validation

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-config "1.0.1-SNAPSHOT"
+(defproject clj-config "1.0.1"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -7,5 +7,8 @@
                  [org.clojure/tools.logging "0.3.1"]]
   :repositories [["primedia"
                   {:url "http://nexus.idg.primedia.com/nexus/content/repositories/primedia"
-                   :sign-releases false}]]
+                   :sign-releases false}]
+                 ["farmlogs-internal" {:url "s3p://fl-maven-repo/mvn"
+                                       :username ~(System/getenv "AMAZON_KEY")
+                                       :passphrase ~(System/getenv "AMAZON_SECRET")}]]
   :signing {:gpg-key "164E1387"})

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-config "1.0.0"
+(defproject clj-config "1.0.1-SNAPSHOT"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"

--- a/src/clj_config/config_entry.clj
+++ b/src/clj_config/config_entry.clj
@@ -16,12 +16,12 @@
      (if (= value ::not-found)
        (throw (ex-info (str "config var " k " not set") {}))
        value)))
-  ([m k {:keys [default parse-fn] :or {parse-fn identity}}]
+  ([m k {:keys [default parser] :or {parser identity}}]
      (when-not m (throw (ex-info "config not initialized" {})))
      (let [value (get-in m (->vec k) ::not-found)]
        (if (= value ::not-found)
          default
-         (parse-fn value)))))
+         (parser value)))))
 
 (defprotocol IValidate
   (-valid? [this value] "Return true if the value is valid, false otherwise."))
@@ -67,12 +67,12 @@
 
 (def +default-validator+ (constantly true))
 (defmethod ->config-entry :default
-  [env lookup-key {:keys [default validator parse-fn] :as options
-                   :or {validator +default-validator+
-                        default +default-sentinel+
-                        parse-fn identity}}]
+  [env lookup-key {:keys [default validator parser] :as options
+                   :or {parser identity
+                        validator +default-validator+
+                        default +default-sentinel+}}]
   (map->ConfigEntry {:default default
                      :env env
                      :lookup-key lookup-key
-                     :parse-fn parse-fn
-                     :validator validator}))
+                     :validator validator
+                     :parser parser}))

--- a/src/clj_config/config_entry.clj
+++ b/src/clj_config/config_entry.clj
@@ -67,8 +67,12 @@
 
 (def +default-validator+ (constantly true))
 (defmethod ->config-entry :default
-  [env lookup-key {:keys [default validator] :as options
+  [env lookup-key {:keys [default validator parse-fn] :as options
                    :or {validator +default-validator+
-                        default +default-sentinel+}}]
-  (assoc (->ConfigEntry env lookup-key validator)
-         :default default))
+                        default +default-sentinel+
+                        parse-fn identity}}]
+  (map->ConfigEntry {:default default
+                     :env env
+                     :lookup-key lookup-key
+                     :parse-fn parse-fn
+                     :validator validator}))

--- a/test/clj_config/config_entry_test.clj
+++ b/test/clj_config/config_entry_test.clj
@@ -15,8 +15,8 @@
                  (= (-lookup config-entry config-data)
                     config-value)))
 
-        :env ["NUMBER" {:parse-fn #(Integer/parseInt %)}] 129
-        :app [[:some :other :key] {:parse-fn str}] "1337"
+        :env ["NUMBER" {:parser #(Integer/parseInt %)}] 129
+        :app [[:some :other :key] {:parser str}] "1337"
 
         :env ["HOME" {:validator string?}] "foo"
         :env ["HOME"]                      "foo"
@@ -52,4 +52,4 @@
                    config-data)
 
         :env "NUMBER"       {:validator integer?
-                             :parse-fn #(Integer/parseInt %)}))))
+                             :parser #(Integer/parseInt %)}))))


### PR DESCRIPTION
This PR ensures that the `parse-fn` provided in the `defconfig` form is respected.

Eg.

``` clojure
(defconfig 
  :env [[port "LISTEN_PORT" {:default 80 :parse-fn #(Integer/parseInt %)}]])
```

This should return an integer instead of a string. When given the following environment:

```
export LISTEN_PORT="80"
```
