### PR TITLE
Dont warn on missing config file

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,4 +7,8 @@
                  [org.clojure/tools.logging "0.3.1"]]
   :repositories [["primedia"
                   {:url "http://nexus.idg.primedia.com/nexus/content/repositories/primedia"
-                   :sign-releases false}]])
+                   :sign-releases false}]
+                 ["farmlogs-internal"
+                  {:url "s3p://fl-maven-repo/mvn"
+                   :username ~(System/getenv "AMAZON_KEY")
+                   :passphrase ~(System/getenv "AMAZON_SECRET")}]])

--- a/src/clj_config/core.clj
+++ b/src/clj_config/core.clj
@@ -27,7 +27,7 @@
           (reduce (fn [acc [k v]] (assoc acc k (-> v trim trim-quotes)))
                   {}
                   (doto (Properties.) (.load (io/input-stream file)))))
-      (log/warnf "Failed to load environment from '%s'. File does not exist." f))))
+      (log/debugf "Failed to load environment from '%s'. File does not exist." f))))
 
 (defn make-path
   [root basename]


### PR DESCRIPTION
clj-config logs missing `.env` files (eg. `.env.local`) as warnings. This results in a surprising log entry in logstash, because our docker containers use environment variables rather than `.env` files for configuration.

In order to reduce the confusion, we dropped the log level of this event from `WARN` to `DEBUG`.
